### PR TITLE
Improved Hazmat Suits Part 1

### DIFF
--- a/code/modules/clothing/suits/f13suits.dm
+++ b/code/modules/clothing/suits/f13suits.dm
@@ -228,8 +228,13 @@
 	mob_overlay_icon = 'icons/fallout/onmob/clothes/suit_utility.dmi'
 	icon_state = "hazmat"
 	item_state = "hazmat"
-	armor = list("melee" = 20, "bullet" = 10, "laser" = 30, "energy" = 25, "bomb" = 16, "bio" = 100, "rad" = 100, "fire" = 0, "acid" = 0)
-
+	w_class = WEIGHT_CLASS_HEAVY
+	slowdown = 0
+	armor = list("melee" = 30, "bullet" = 10, "laser" = 30, "energy" = 25, "bomb" = 16, "bio" = 100, "rad" = 100, "fire" = 0, "acid" = 100)
+	var/obj/item/clothing/head/bio_hood/f13/hazmat
+	actions_types = list(/datum/action/item_action/toggle_helmet)
+	var/helmettype = /obj/item/clothing/head/bio_hood/f13/hazmat
+	
 /obj/item/clothing/head/bio_hood/f13/hazmat
 	name = "hazmat hood"
 	desc = "My star, my perfect silence."
@@ -237,7 +242,7 @@
 	icon_state = "hazmat"
 	item_state = "hazmat_helmet"
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|HIDEHAIR|HIDEFACIALHAIR
-	armor = list("melee" = 29, "bullet" = 10, "laser" = 30, "energy" = 25, "bomb" = 16, "bio" = 100, "rad" = 100, "fire" = 0, "acid" = 0)
+	armor = list("melee" = 30, "bullet" = 10, "laser" = 30, "energy" = 25, "bomb" = 16, "bio" = 100, "rad" = 100, "fire" = 0, "acid" = 100)
 
 //Fallout 13 toggle apparel directory
 /obj/item/clothing/suit/toggle/labcoat/f13/emergency


### PR DESCRIPTION
This is the first of 2 prs to make hazmat suits better, and actually worth using. It removes the slowdown of the suit, increases the melee resistance of the armor itself by a bit, acid proofs it, makes the helmet part of the suit instead of a separate object, and lets you put it in your backpack.

2 part series of prs, second one will update the sprite for the hazmat suit to make it more similar to fallout 4's